### PR TITLE
Improved Error Messages for Port Scanner

### DIFF
--- a/portscanner.py
+++ b/portscanner.py
@@ -48,13 +48,6 @@ def parse_arguments():
     parser.add_argument("--output", help="File path to save the scan report.")
     return parser.parse_args()
 
-    # Added a check to ensure End_Port is >= Start_Port.
-    if args.End_Port < args.Start_Port:
-        print(RED + "[Error] End_Port should be greater than or equal to Start_Port." + RESET)
-        sys.exit()
-
-    return args
-
 def resolve_target(target):
     try:
         ip = socket.gethostbyname(target)


### PR DESCRIPTION
This PR addresses [issue #10](https://github.com/theinit01/portscanner/issues/10).

I made a few updates to the `portscanner.py` script to make it easier to use:

1. More Understandable Error Messages: If there's trouble figuring out a computer's name, you'll now get a message that's easier to get.
2. Better Scanning Feedback: If the script takes too long on a port, it'll let you know. Plus, if anything else goes wrong, it'll give more details.

